### PR TITLE
ellia/UI for posts indicating that the post has been endorsed by instructor

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -62,6 +62,9 @@
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
 		</div>
+		<div style="color: green; text-align: center; font-weight:bold;">
+			~This comment has been endorsed by an instructor~
+		</div>
 	</div>
 </div>
 

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -62,9 +62,11 @@
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
 		</div>
-		<div style="color: green; text-align: center; font-weight:bold;">
-			~This comment has been endorsed by an instructor~
-		</div>
+		{{{ if posts.endorsed }}}
+			<div class="post-endorsed-message" style="color: green; text-align: center; font-weight: bold;">
+				~This comment has been endorsed by an instructor~
+			</div>
+		{{{ end }}}
 	</div>
 </div>
 
@@ -98,12 +100,12 @@
 	<div component="post/actions" class="d-flex justify-content-end gap-1 post-tools">
 		<!-- IMPORT partials/topic/reactions.tpl -->
 		{{{ if privileges.isAdminOrMod }}} <!-- Check if the user is an admin -->
-        <a component="post/endorse" href="#" class="btn-ghost-sm{{{ if posts.endorsed }}} endorsed{{{ end }}}" title="[[topic:Endorse]]" onclick="endorsePost({posts.pid})">
+        <a component="post/endorse" href="#" class="btn-ghost-sm{{{ if posts.endorsed}}} endorsed{{{ end }}}" title="[[topic:Endorse]]">
             <i class="fa fa-fw fa-thumbs-{{{ if posts.endorsed }}}up{{{ else }}}o-up{{{ end }}} text-primary"></i>
         </a>
 		{{{ end }}}
-</a>
-<a component="post/reply" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
+
+		<a component="post/reply" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
 		<a component="post/quote" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
 
 		{{{ if !reputation:disabled }}}


### PR DESCRIPTION
I added a conditional that checks for the field in the posts object. If posts.endorsed is true, it displays the div that shows “~ This post is endorsed by an instructor ~” within the area of the post under the content and above the tools. This resolves #3 in the main project board